### PR TITLE
Adds IEEE Xplore to the list of websites to scrape for search history

### DIFF
--- a/hg-setup.js
+++ b/hg-setup.js
@@ -252,6 +252,10 @@ function buildAvailableHistoryList(divName, cutoff, shortQueryThreshold) {
     {'website':'Google',
       'matchpattern':'google.com/search?q=',
       'queryextractor':function(h) { return h.title.slice(0,-15); }
+    },
+    {'website':'IEEE Xplore',
+      'matchpattern':'ieeexplore.ieee.org/search/searchresult.jsp?',
+      'queryextractor':function(h) { return (new URLSearchParams(h.url)).get('queryText'); }
     }
   ]
 


### PR DESCRIPTION
This proposed change would add IEEE Xplore history items to the printable search history. I used the chrome-native URLSearchParams object to handle the query string.